### PR TITLE
fix: serialize message do not have signature

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -430,7 +430,8 @@ class Torus {
   async sendTransaction(transaction: Transaction): Promise<string> {
     const response = (await this.provider.request({
       method: "send_transaction",
-      params: { message: transaction.serializeMessage().toString("hex") },
+      // params: { message: transaction.serializeMessage().toString("hex") },
+      params: { message: transaction.serialize({ requireAllSignatures: false }).toString("hex") },
     })) as string;
     return response;
   }
@@ -438,7 +439,8 @@ class Torus {
   async signTransaction(transaction: Transaction): Promise<Transaction> {
     const response = (await this.provider.request({
       method: "sign_transaction",
-      params: { message: transaction.serializeMessage().toString("hex") },
+      // params: { message: transaction.serializeMessage().toString("hex") },
+      params: { message: transaction.serialize({ requireAllSignatures: false }).toString("hex") },
     })) as string;
 
     const buf = Buffer.from(response, "hex");


### PR DESCRIPTION
Embed transaction messaging to use Transaction.sequelize instead of Message
Embed Transactions sendAsync use Message.serialze() would miss out signatures if the Transaction multiple signed but other parties
Transaction.sequelize({requireAllSignature }) will have the signature and Message

This PR require 
https://github.com/torusresearch/solana-wallet/pull/83